### PR TITLE
Fix dark mode background

### DIFF
--- a/Sources/SwiftUIPullToRefresh/SwiftUIPullToRefresh.swift
+++ b/Sources/SwiftUIPullToRefresh/SwiftUIPullToRefresh.swift
@@ -103,7 +103,7 @@ public struct RefreshableScrollView<Progress, Content>: View where Progress: Vie
           // The loading view. It's offset to the top of the content unless we're loading.
           ZStack {
             Rectangle()
-              .foregroundColor(.white)
+              .foregroundColor(Color(UIColor.systemBackground))
               .frame(height: THRESHOLD)
             progress(state)
           }.offset(y: (state == .loading) ? 0 : -THRESHOLD)


### PR DESCRIPTION
This change fixes a bug where the loading view would always be white, while it should respect dark mode.

![darkmodebug](https://user-images.githubusercontent.com/8880568/137873479-93fadcc4-9d77-4b6b-9c1d-e8106d7858bc.jpg)

