### PR TITLE
Remove unnecessary version check

### DIFF
--- a/Sources/SwiftUIPullToRefresh/SwiftUIPullToRefresh.swift
+++ b/Sources/SwiftUIPullToRefresh/SwiftUIPullToRefresh.swift
@@ -275,20 +275,12 @@ public extension List {
                                                         threshold: CGFloat = defaultRefreshThreshold,
                                                         onRefresh: @escaping OnRefresh,
                                                         @ViewBuilder progress: @escaping RefreshProgressBuilder<Progress>) -> some View {
-        if #available(iOS 15.0, macOS 12.0, *) {
-            self.refreshable {
-                await withCheckedContinuation { cont in
-                    onRefresh {
-                        cont.resume()
-                    }
+        self.refreshable {
+            await withCheckedContinuation { cont in
+                onRefresh {
+                    cont.resume()
                 }
             }
-        } else {
-            self.modifier(RefreshableCompat(showsIndicators: showsIndicators,
-                                            loadingViewBackgroundColor: loadingViewBackgroundColor,
-                                            threshold: threshold,
-                                            onRefresh: onRefresh,
-                                            progress: progress))
         }
     }
 }


### PR DESCRIPTION
Because the extension is already listed as `available(iOS 15.0, *)`, checking for it again in the body is redundant. Xcode also gives a warning against this unnecessary check.