### PR TITLE
Add percent parameter to `RefreshProgressBuilder` and optional animation effect on `RefreshActivityIndicator`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ https://github.com/globulus/swiftui-pull-to-refresh
 You can also use **CocoaPods**:
 
 ```ruby
-pod 'SwiftUI-Pull-To-Refresh', '~> 1.1.9'
+pod 'SwiftUI-Pull-To-Refresh', '~> 2.0.0'
 ```
 
 ## Sample usage

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ RefreshableScrollView(
 
 ## Changelog
 
-* 2.0.0 - Changed `RefreshProgressBuilder` to take an extra `percent` value in the range `0...1` and added a `RefreshActivityIndicator.masked(state: RefreshState, percent: Double)` modifier for iOS 15+
+* 2.0.0 - Changed `RefreshProgressBuilder` to take an extra `percent` value in the range `0...1`. Added a `RefreshActivityIndicator.masked(state: RefreshState, percent: Double)` modifier for iOS 15+. Fixed warning on `refreshableCompat`.
 * 1.1.9 - Reworked haptic feedback, added haptic feedback as optional.
 * 1.1.8 - Fixed crash when doing two pulls quickly in succession.
 * 1.1.7 - Updated haptic feedback. Increased Swift version for Podspec.

--- a/README.md
+++ b/README.md
@@ -133,8 +133,43 @@ progress: { state in // HERE
 
 Check out [this recipe](https://swiftuirecipes.com/blog/pull-to-refresh-with-swiftui-scrollview) for in-depth description of the component and its code. Check out [SwiftUIRecipes.com](https://swiftuirecipes.com) for more **SwiftUI recipes**!
 
+## Changes in Version 2.0.0
+
+### RefreshProgressBuilder updated to take percent value in range 0...1
+
+`RefreshProgressBuilder` now takes two parameters, the refresh state and a percent value in the range `0...1` which is the `offset` as a percentage of the `threshold` value; this can be used to update graphics as the user pulls down to get animated effects.
+
+### RefreshActivityIndicator mask on iOS 15+
+
+ This modifier is designed to be used with the updated `RefreshProgressBuilder` parameters `state` and `percent`, and adds a mask on iOS 15+ that recreates the capsule animation effect of `UIRefreshControl` as the user drags down.
+
+ The modifier has no effect on iOS 13 and 14 and returns `self`.
+
+ ```swift
+RefreshableScrollView(
+  onRefresh: { done in
+    DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+      self.now = Date()
+      done()
+    }
+  }, progress: { state, percent in
+      RefreshActivityIndicator(isAnimating: state == .loading) {
+          $0.hidesWhenStopped = false
+          $0.style = .large
+      }.masked(state: state, percent: percent) // this performs animation as user drags
+  }) {
+    VStack {
+      ForEach(1..<20) {
+        Text("\(Calendar.current.date(byAdding: .hour, value: $0, to: now)!)")
+            .padding(.bottom, 10)
+        }
+      }.padding()
+    }
+```
+
 ## Changelog
 
+* 2.0.0 - Changed `RefreshProgressBuilder` to take an extra `percent` value in the range `0...1` and added a `RefreshActivityIndicator.masked(state: RefreshState, percent: Double)` modifier for iOS 15+
 * 1.1.9 - Reworked haptic feedback, added haptic feedback as optional.
 * 1.1.8 - Fixed crash when doing two pulls quickly in succession.
 * 1.1.7 - Updated haptic feedback. Increased Swift version for Podspec.

--- a/Sources/SwiftUIPullToRefresh/SwiftUIPullToRefresh.swift
+++ b/Sources/SwiftUIPullToRefresh/SwiftUIPullToRefresh.swift
@@ -328,20 +328,12 @@ public extension List {
                                                         threshold: CGFloat = defaultRefreshThreshold,
                                                         onRefresh: @escaping OnRefresh,
                                                         @ViewBuilder progress: @escaping RefreshProgressBuilder<Progress>) -> some View {
-        if #available(iOS 15.0, macOS 12.0, *) {
-            self.refreshable {
-                await withCheckedContinuation { cont in
-                    onRefresh {
-                        cont.resume()
-                    }
+        self.refreshable {
+            await withCheckedContinuation { cont in
+                onRefresh {
+                    cont.resume()
                 }
             }
-        } else {
-            self.modifier(RefreshableCompat(showsIndicators: showsIndicators,
-                                            loadingViewBackgroundColor: loadingViewBackgroundColor,
-                                            threshold: threshold,
-                                            onRefresh: onRefresh,
-                                            progress: progress))
         }
     }
 }

--- a/SwiftUI-Pull-To-Refresh.podspec
+++ b/SwiftUI-Pull-To-Refresh.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'SwiftUI-Pull-To-Refresh'
-  s.version          = '1.1.9'
+  s.version          = '2.0.0'
   s.summary          = 'Pull to refresh on any SwiftUI Scroll View.'
   s.homepage         = 'https://github.com/globulus/swiftui-pull-to-refresh'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }


### PR DESCRIPTION
This changes the public API for `RefreshProgressBuilder` so that it takes an extra parameter called percentage in the range of `0...1` (the offset / threshold) so that you can do animated effects when dragging down.

I've added an modifier to add a mask on iOS 15+ on the `RefreshActivityIndicator` to get the animated effect of `UIRefreshControl` when the user drags down.

Because it's a public API change, I've bumped the version to 2.0.0.

![refresh-control-animation](https://github.com/globulus/swiftui-pull-to-refresh/assets/725787/2add4037-cace-4f58-a916-519ef1dc3d71)
